### PR TITLE
Rename product name

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -22,16 +22,16 @@ jobs:
           # Generate `gitleaks` binary
           tar --extract --gzip --file "gitleaks_${VERSION}_${TARGET}.tar.gz" --verbose
           sudo install gitleaks /usr/local/bin/gitleaks
-      - name: Setup gitleaks-support
+      - name: Setup gls
         env:
           TARGET: x86_64-unknown-linux-gnu
           VERSION: "0.1.1"
-          # From https://github.com/Finatext/gitleaks-support/releases/download/v${VERSION}/gitleaks-support-${TARGET}.tar.gz.sha256
+          # From https://github.com/Finatext/gls/releases/download/v${VERSION}/gls-${TARGET}.tar.gz.sha256
           SHA256_SUM: 162f2fdb98abba26e05be60137a48b98feec3e3a6e48e68bc0c219a0f32fbd0f
         shell: bash
         run: |
           set -x
-          curl -L "https://github.com/Finatext/gitleaks-support/releases/download/v${VERSION}/gitleaks-support-${TARGET}.tar.gz" -O
+          curl -L "https://github.com/Finatext/gls/releases/download/v${VERSION}/gitleaks-support-${TARGET}.tar.gz" -O
           echo "${SHA256_SUM} gitleaks-support-${TARGET}.tar.gz" | sha256sum --check
           tar --extract --gzip --file "gitleaks-support-${TARGET}.tar.gz" --verbose
           sudo install gitleaks-support /usr/local/bin/gitleaks-support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
-name = "gitleaks-support"
+name = "gls"
 version = "0.1.1"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "gitleaks-support"
+name = "gls"
 description = "Support gitleaks config development and extend some gitleaks features."
 version = "0.1.1"
 edition = "2021"
 rust-version = "1.70.0"
 readme = "README.md"
-homepage = "https://github.com/Finatext/gitleaks-support"
-repository = "https://github.com/Finatext/gitleaks-support"
+homepage = "https://github.com/Finatext/gls"
+repository = "https://github.com/Finatext/gls"
 license = "MIT"
 keywords = ["gitleaks", "secrets-scanning", "code-scanning", "security", "git"]
 categories = ["command-line-utilities"]

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# gitleaks-support
+# gls
 
-gitleaks-support enhances the development of gitleaks rules and allowlists, and extends gitleaks features with:
+gls (gitleaks-support) enhances the development of gitleaks rules and allowlists, and extends gitleaks features with:
 
 - Support for multiple global and rule-specific allowlists.
 - Ability to handle multiple configuration files.
 
 ## Design
 
-Instead of using the original gitleaks allowlist feature, gitleaks-support requires all allowlists to be defined in its own configuration files.
+Instead of using the original gitleaks allowlist feature, gls requires all allowlists to be defined in its own configuration files.
 
-During the detection phase, gitleaks produces findings which are then filtered by gitleaks-support according to its allowlist configurations.
+During the detection phase, gitleaks produces findings which are then filtered by gls according to its allowlist configurations.
 
 ## User Journey
 
@@ -17,23 +17,23 @@ There are two main phases: config development and detection.
 
 ### Config Development
 
-To set up for development, gitleaks-support provides the following CLI commands:
+To set up for development, gls provides the following CLI commands:
 
-- `extract-allowlist`: This command extracts allowlist items from a specified gitleaks configuration file to a gitleaks-support configuration file.
+- `extract-allowlist`: This command extracts allowlist items from a specified gitleaks configuration file to a gls configuration file.
 - `cleanup-allowlist`: This removes all allowlist items from a specified gitleaks configuration file.
 - `cleanup-rule`: This removes all detection rules from a specified gitleaks configuration file.
 
-Once the gitleaks configuration file is cleaned and the gitleaks-support allowlist configuration files are set, you can validate and develop your allowlist configuration.
+Once the gitleaks configuration file is cleaned and the gls allowlist configuration files are set, you can validate and develop your allowlist configuration.
 
 - `scan`: Executes the gitleaks detection command on specified git repositories using multiple threads.
 - `review`: Reviews the results of the aforementioned scan (gitleaks report JSON files), including summaries, lists of findings per detection rule, and lists of results per allowlist.
 
-For ongoing configuration development in day-to-day operations, gitleaks-support also offers:
+For ongoing configuration development in day-to-day operations, gls also offers:
 
-- `diff`: Compares two `gitleaks-support review` result JSON files to identify differences in both allowed and confirmed findings.
+- `diff`: Compares two `gls review` result JSON files to identify differences in both allowed and confirmed findings.
 
 ### Detection
 
 To filter the results from `gitleaks detect`:
 
-- `apply`: Takes gitleaks-support configuration files and a gitleaks detection result JSON file, and outputs the actual confirmed findings.
+- `apply`: Takes gls configuration files and a gitleaks detection result JSON file, and outputs the actual confirmed findings.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::process::ExitCode;
 
-use gitleaks_support::cli::run;
+use gls::cli::run;
 
 fn main() -> anyhow::Result<ExitCode> {
     run()


### PR DESCRIPTION
gitleaks-support is a bit longer to use.