### PR TITLE
Follow product rename

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -25,16 +25,16 @@ jobs:
       - name: Setup gls
         env:
           TARGET: x86_64-unknown-linux-gnu
-          VERSION: "0.1.1"
+          VERSION: "0.1.2"
           # From https://github.com/Finatext/gls/releases/download/v${VERSION}/gls-${TARGET}.tar.gz.sha256
-          SHA256_SUM: 162f2fdb98abba26e05be60137a48b98feec3e3a6e48e68bc0c219a0f32fbd0f
+          SHA256_SUM: d7ce5c901b03ae81b10ccd41d7a0328d9752a45e6433cac27e7720d15462c9a7
         shell: bash
         run: |
           set -x
-          curl -L "https://github.com/Finatext/gls/releases/download/v${VERSION}/gitleaks-support-${TARGET}.tar.gz" -O
-          echo "${SHA256_SUM} gitleaks-support-${TARGET}.tar.gz" | sha256sum --check
-          tar --extract --gzip --file "gitleaks-support-${TARGET}.tar.gz" --verbose
-          sudo install gitleaks-support /usr/local/bin/gitleaks-support
+          curl -L "https://github.com/Finatext/gls/releases/download/v${VERSION}/gls-${TARGET}.tar.gz" -O
+          echo "${SHA256_SUM} gls-${TARGET}.tar.gz" | sha256sum --check
+          tar --extract --gzip --file "gls-${TARGET}.tar.gz" --verbose
+          sudo install gls /usr/local/bin/gls
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Scan secrets
         env:
@@ -44,4 +44,4 @@ jobs:
           set -x
           mkdir -p tmp
           gitleaks detect --verbose --exit-code=0 --no-banner --config=dev/gitleaks.toml --report-path="${REPORT_PATH}"
-          gitleaks-support apply --config-path=dev/gitleaks-allowlist.toml --report-path="${REPORT_PATH}"
+          gls apply --config-path=dev/gitleaks-allowlist.toml --report-path="${REPORT_PATH}"


### PR DESCRIPTION
After https://github.com/Finatext/gls/pull/2 , pushed new release v0.1.2 as gls name so use them in CI jobs.