### PR TITLE
Remove auto Homebrew formula update job

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -121,33 +121,3 @@ jobs:
         files: |
           ${{ needs.crate-metadata.outputs.name }}-${{ matrix.job.target }}.tar.gz
           ${{ needs.crate-metadata.outputs.name }}-${{ matrix.job.target }}.tar.gz.sha256
-
-  update-homebrew:
-    needs:
-      - build-release
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      with:
-        ref: main
-    - name: Update Homebrew Formula
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_REF: ${{ github.ref }}
-        TARGET: gls
-      shell: bash
-      run: |
-        .github/scripts/update_formula
-    - name: Commit and push changes
-      shell: bash
-      run: |
-        set -x
-        # https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-using-the-built-in-token
-        git config user.name "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git diff
-        git add HomebrewFormula/gls.rb
-        git commit -m "Update Homebrew formula"
-        git push

--- a/README.md
+++ b/README.md
@@ -51,3 +51,12 @@ For ongoing configuration development in day-to-day operations, gls also offers:
 To filter the results from `gitleaks detect`:
 
 - `apply`: Takes gls configuration files and a gitleaks detection result JSON file, and outputs the actual confirmed findings.
+
+## Development
+### Release
+1. Update version of `Cargo.toml` and re-generate lock file
+1. Git commit-push then create a PR and merge
+1. Create a git tag with `git tag "$(cargo metadata --no-deps --format-version 1 | jq -r '"v" + .packages[0].version')"`
+1. Push the git tag and wait the CI creates a GitHub Release and upload artifacts
+1. Run `.github/scripts/update_formula` to update Homebrew formula file
+1. Create a PR adn merge


### PR DESCRIPTION
With branch protection rules, GitHub Actions can not push the branch directly or create PRs. To work-around this, stop auto Homebrew formula update job temporary.

Creating dedicated GitHub App can solve this problem, as GitHub App can bypass branch protection rules. https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository#granting-bypass-permissions-for-your-branch-or-tag-ruleset