### PR TITLE
Move to canonical gitleaks

### DIFF
--- a/.github/actions/setup_gitleaks/action.yml
+++ b/.github/actions/setup_gitleaks/action.yml
@@ -1,20 +1,21 @@
 name: "Setup gitleaks"
+description: "Setup gitleaks"
 runs:
   using: "composite"
   steps:
     - name: Setup gitleaks
       env:
-        TARGET: linux_amd64
-        VERSION: 8.18.1-patch1
-        # From https://github.com/taiki45/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_checksums.txt
-        SHA256_SUM: aed536718ac444b6727754ca2e34e243ec1aee8bce928975233709d57bc61387
+        TARGET: linux_x64
+        VERSION: 8.23.3
+        # From https://github.com/gitleaks/gitleaks/releases/
+        SHA256_SUM: 73a35edc2285afd689e712b8e0ebad3f2eaf94b0d67cd6e1f0ec693ac751bb4a
       # Explicitly specifing `bash` changes behavior: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
       shell: bash
       run: |
         set -x
         curl --silent --show-error --fail --connect-timeout 3 --max-time 10 --retry 3 \
           --location --remote-name \
-          "https://github.com/taiki45/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_${TARGET}.tar.gz"
+          "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_${TARGET}.tar.gz"
         echo "${SHA256_SUM} gitleaks_${VERSION}_${TARGET}.tar.gz" | sha256sum --check
         # Generate `gitleaks` binary
         tar --extract --gzip --file "gitleaks_${VERSION}_${TARGET}.tar.gz" --verbose

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -32,5 +32,7 @@ jobs:
         run: |
           set -x
           mkdir -p tmp
-          gitleaks detect --verbose --exit-code=0 --no-banner --config=dev/gitleaks.toml --report-path="${REPORT_PATH}"
+          gitleaks git --verbose --exit-code=0 --no-banner \
+            --report-format template --report-template dev/jsonextra.json.tmpl \
+            --config=dev/gitleaks.toml --report-path="${REPORT_PATH}"
           gls apply --config-path=dev/gitleaks-allowlist.toml --report-path="${REPORT_PATH}"

--- a/.github/workflows/test-annotation.yml
+++ b/.github/workflows/test-annotation.yml
@@ -40,6 +40,8 @@ jobs:
         run: |
           set -x
           mkdir -p tmp
-          gitleaks detect --verbose --exit-code=0 --no-banner --config=tests/testdata/scan_config.toml --report-path="${REPORT_PATH}"
+          gitleaks detect --verbose --exit-code=0 --no-banner \
+            --report-format template --report-template dev/jsonextra.json.tmpl \
+            --config=tests/testdata/scan_config.toml --report-path="${REPORT_PATH}"
           cargo run apply --no-fail --format=sarif --config-path=tests/testdata/empty_allowlist.toml | \
             reviewdog -f=sarif -reporter=github-pr-check -level=warning -name=gls

--- a/.github/workflows/test-annotation.yml
+++ b/.github/workflows/test-annotation.yml
@@ -7,27 +7,11 @@ jobs:
     name: Test GitHub annotation
     runs-on: ubuntu-latest
     steps:
-      - name: Setup gitleaks
-        env:
-          TARGET: linux_amd64
-          VERSION: 8.18.1-patch1
-          # From https://github.com/taiki45/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_checksums.txt
-          SHA256_SUM: aed536718ac444b6727754ca2e34e243ec1aee8bce928975233709d57bc61387
-        # Explicitly specifing `bash` changes behavior: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
-        shell: bash
-        run: |
-          set -x
-          curl --silent --show-error --fail --connect-timeout 3 --max-time 10 --retry 3 \
-            --location --remote-name \
-            "https://github.com/taiki45/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_${TARGET}.tar.gz"
-          echo "${SHA256_SUM} gitleaks_${VERSION}_${TARGET}.tar.gz" | sha256sum --check
-          # Generate `gitleaks` binary
-          tar --extract --gzip --file "gitleaks_${VERSION}_${TARGET}.tar.gz" --verbose
-          sudo install gitleaks /usr/local/bin/gitleaks
       - uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c # No semver tag.
         with:
           toolchain: stable
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: ./.github/actions/setup_gitleaks
       - uses: reviewdog/action-setup@3f401fe1d58fe77e10d665ab713057375e39b887 # v1.3.0
         with:
           reviewdog_version: latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,7 +343,7 @@ checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "gls"
-version = "0.1.18"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,7 @@ dependencies = [
  "predicates",
  "rayon",
  "regex",
+ "semver",
  "serde",
  "serde_json",
  "tabled",
@@ -671,6 +672,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gls"
 description = "Support gitleaks config development and extend some gitleaks features."
-version = "0.1.18"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.70.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tabled = "0"
+tempfile = "3"
 toml = "0"
 toml_edit = { version = "0" }
 
@@ -27,7 +28,7 @@ toml_edit = { version = "0" }
 assert_cmd = "2"
 indoc = "2"
 predicates = "3"
-tempfile = "3"
+semver = "1"
 
 [lints.clippy]
 # Enable some restriction lints.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ gls (gitleaks-support) enhances the development of gitleaks rules and allowlists
 - Support for multiple global and rule-specific allowlists.
 - Ability to handle multiple configuration files.
 
+## Gitleaks Version
+gls requires gitleaks (>= v8.21.3).
+
 ## Install
 ### Homebrew
 ```

--- a/dev/jsonextra.json.tmpl
+++ b/dev/jsonextra.json.tmpl
@@ -1,0 +1,25 @@
+[{{ $lastFinding := (sub (len . ) 1) }}
+{{- range $i, $finding := . }}{{with $finding}}
+    {
+        "Description": {{ quote .Description }},
+        "StartLine": {{ .StartLine }},
+        "EndLine": {{ .EndLine }},
+        "StartColumn": {{ .StartColumn }},
+        "EndColumn": {{ .EndColumn }},
+        "Line": {{ quote .Line }},
+        "Match": {{ quote .Match }},
+        "Secret": {{ quote .Secret }},
+        "File": "{{ .File }}",
+        "SymlinkFile": {{ quote .SymlinkFile }},
+        "Commit": {{ quote .Commit }},
+        "Entropy": {{ .Entropy }},
+        "Author": {{ quote .Author }},
+        "Email": {{ quote .Email }},
+        "Date": {{ quote .Date }},
+        "Message": {{ quote .Message }},
+        "Tags": [{{ $lastTag := (sub (len .Tags ) 1) }}{{ range $j, $tag := .Tags }}{{ quote . }}{{ if ne $j $lastTag }},{{ end }}{{ end }}],
+        "RuleID": {{ quote .RuleID }},
+        "Fingerprint": {{ quote .Fingerprint }}
+    }{{ if ne $i $lastFinding }},{{ end }}
+{{- end}}{{ end }}
+]

--- a/src/data/jsonextra.json.tmpl
+++ b/src/data/jsonextra.json.tmpl
@@ -1,0 +1,25 @@
+[{{ $lastFinding := (sub (len . ) 1) }}
+{{- range $i, $finding := . }}{{with $finding}}
+    {
+        "Description": {{ quote .Description }},
+        "StartLine": {{ .StartLine }},
+        "EndLine": {{ .EndLine }},
+        "StartColumn": {{ .StartColumn }},
+        "EndColumn": {{ .EndColumn }},
+        "Line": {{ quote .Line }},
+        "Match": {{ quote .Match }},
+        "Secret": {{ quote .Secret }},
+        "File": "{{ .File }}",
+        "SymlinkFile": {{ quote .SymlinkFile }},
+        "Commit": {{ quote .Commit }},
+        "Entropy": {{ .Entropy }},
+        "Author": {{ quote .Author }},
+        "Email": {{ quote .Email }},
+        "Date": {{ quote .Date }},
+        "Message": {{ quote .Message }},
+        "Tags": [{{ $lastTag := (sub (len .Tags ) 1) }}{{ range $j, $tag := .Tags }}{{ quote . }}{{ if ne $j $lastTag }},{{ end }}{{ end }}],
+        "RuleID": {{ quote .RuleID }},
+        "Fingerprint": {{ quote .Fingerprint }}
+    }{{ if ne $i $lastFinding }},{{ end }}
+{{- end}}{{ end }}
+]

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use anyhow::{bail, Context, Result};
+use semver::Version;
 use tempfile::{tempdir, TempDir};
 
 struct Git<'path> {
@@ -43,10 +44,12 @@ pub fn check_gitleaks() -> Result<()> {
 
     let mut cmd = Command::new("gitleaks");
     cmd.arg("version");
-    let res = cmd.output()?;
-    let version = String::from_utf8_lossy(&res.stdout);
-    if !version.contains("-patch") {
-        bail!("gitleaks version is not patched. Please install patched version gitleaks. See .github/workflows/cicd.yml to setup.")
+    let output = cmd.output()?;
+    let version_string = String::from_utf8_lossy(&output.stdout);
+    let version = Version::parse(version_string.trim())?;
+    let expected = Version::parse("8.21.3")?;
+    if version < expected {
+        bail!("gitleaks is too old. Please install latest gitleaks. See .github/workflows/cicd.yml to setup: detected={}, expected={}", version, expected);
     }
     Ok(())
 }


### PR DESCRIPTION
Historically gls requires more extended gitleaks outputs, which include `Line` field. Recent gitleaks implemented the feature so move to canonical gitleaks from patched one.

>feat(report): allow user-defined templates

https://github.com/gitleaks/gitleaks/releases/tag/v8.21.3